### PR TITLE
Add new callback: OnThumbMoveCallback

### DIFF
--- a/RangeBarSample/src/com/appyvet/rangebarsample/MainActivity.java
+++ b/RangeBarSample/src/com/appyvet/rangebarsample/MainActivity.java
@@ -15,6 +15,7 @@ import android.widget.EditText;
 import android.widget.SeekBar;
 import android.widget.SeekBar.OnSeekBarChangeListener;
 import android.widget.TextView;
+import android.widget.Toast;
 
 public class MainActivity extends Activity implements
         ColorPickerDialog.OnColorSelectedListener {
@@ -107,6 +108,20 @@ public class MainActivity extends Activity implements
                 rightIndexValue.setText("" + rightPinIndex);
             }
 
+        });
+
+        rangebar.setThumbMoveListener(new RangeBar.OnThumbMoveListener() {
+            @Override
+            public void onThumbMovingStart(RangeBar rangeBar, boolean isLeftThumb) {
+                String toast = (isLeftThumb ? "Left" : "Right") + " thumb starts moving";
+                Toast.makeText(MainActivity.this, toast, Toast.LENGTH_SHORT).show();
+            }
+
+            @Override
+            public void onThumbMovingStop(RangeBar rangeBar, boolean isLeftThumb) {
+                String toast = (isLeftThumb ? "Left" : "Right") + " thumb stops moving";
+                Toast.makeText(MainActivity.this, toast, Toast.LENGTH_SHORT).show();
+            }
         });
 
         // Sets the indices themselves upon input from the user

--- a/rangebar/src/com/appyvet/rangebar/RangeBar.java
+++ b/rangebar/src/com/appyvet/rangebar/RangeBar.java
@@ -154,6 +154,8 @@ public class RangeBar extends View {
 
     private OnRangeBarTextListener mPinTextListener;
 
+    private OnThumbMoveListener mThumbMoveListener;
+
     private HashMap<Float, String> mTickMap;
 
     private int mLeftIndex;
@@ -486,6 +488,16 @@ public class RangeBar extends View {
     public void setPinTextListener(OnRangeBarTextListener mPinTextListener) {
         this.mPinTextListener = mPinTextListener;
     }
+
+    /**
+     * Sets a listener to receive notifications of thumb moving.
+     * @param thumbMoveListener the thumb move notification listener; null to remove any existing
+     *                          listener
+     */
+    public void setThumbMoveListener(OnThumbMoveListener thumbMoveListener) {
+        this.mThumbMoveListener = thumbMoveListener;
+    }
+
 
 
     public void setFormatter(IRangeBarFormatter formatter) {
@@ -1235,7 +1247,6 @@ public class RangeBar extends View {
             if (!mRightThumb.isPressed() && mLeftThumb.isInTargetZone(x, y)) {
 
                 pressPin(mLeftThumb);
-
             } else if (!mLeftThumb.isPressed() && mRightThumb.isInTargetZone(x, y)) {
 
                 pressPin(mRightThumb);
@@ -1374,6 +1385,14 @@ public class RangeBar extends View {
             animator.start();
         }
 
+        if (mThumbMoveListener != null) {
+            if (thumb == mLeftThumb) {
+                mThumbMoveListener.onThumbMovingStart(this, true);
+            } else {
+                mThumbMoveListener.onThumbMovingStart(this, false);
+            }
+        }
+
         thumb.press();
     }
 
@@ -1405,6 +1424,14 @@ public class RangeBar extends View {
             animator.start();
         } else {
             invalidate();
+        }
+
+        if (mThumbMoveListener != null) {
+            if (thumb == mLeftThumb) {
+                mThumbMoveListener.onThumbMovingStop(this, true);
+            } else {
+                mThumbMoveListener.onThumbMovingStop(this, false);
+            }
         }
 
         thumb.release();
@@ -1477,6 +1504,17 @@ public class RangeBar extends View {
     public static interface OnRangeBarTextListener {
 
         public String getPinValue(RangeBar rangeBar, int tickIndex);
+    }
+
+    /**
+     * @author Xiaofei
+     *         A callback that notify the observer range bar start/stop dragging
+     *         This callback will avoid do some time-consuming job too frequently
+     */
+    public interface OnThumbMoveListener {
+        void onThumbMovingStart(RangeBar rangeBar, boolean isLeftThumb);
+
+        void onThumbMovingStop(RangeBar rangeBar, boolean isLeftThumb);
     }
 
 


### PR DESCRIPTION
Some time-consuming job may be done when range bar is changed.
Without this callback, it will be executed frequently. Now it can just be
executed when thumb press is up.
